### PR TITLE
Fixes this bug starting quay.io/kanboard/kanboard:v1.2.43

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -9,4 +9,4 @@ fi
 chown -R nginx:nginx /var/www/app/data
 chown -R nginx:nginx /var/www/app/plugins
 
-exec /bin/s6-svscan /etc/services.d
+exec s6-svscan /etc/services.d


### PR DESCRIPTION
Fixes issue #16 

Tested kanboard/kanboard:v1.2.43 and kanboard/kanboard:v1.2.13


## kanboard/kanboard:v1.2.43
```
kanext-kanboard  | PHP message: [debug] SQL: param[2]: 'csrf|a:7:{s:60:"3b6cfd070b57e0bf5dffd9a8a51c7ca05c8510569afee518fc7091a37ff2";b:1;s:60:"bee4b858a95a60169745ffc37b2e8b3d4e3128e33bbcb2bd25eddf81b93c";b:1;s:60:"37601cca0a47fe01f5507138865421abd1800f5a39ea28479ab11e2c3c3b";b:1;s:60:"472b81aab76b9d990e2f9ae59bfc78b25c82bf99862b355335685be87b2e";b:1;s:60:"a2bebfc9fc8a2e9aa24d1527f87ad3091bc15b62654157673648dc7420a4";b:1;s:60:"6475453f7b4aeab094c938179624954845222fd50673905167f51b0c4c0e";b:1;s:60:"b5dd6de69d8275d21b7d35838f0b327789e81c2e6cdc60abe975047cf31c";b:1;}hasRememberMe|b:1;user|a:23:{s:2:"id";i:1;s:8:"username";s:5:"admin";s:12:"is_ldap_user";b:0;s:4:"name";N;s:5:"email";N;s:9:"google_id";N;s:9:"github_id";N;s:21:"notifications_enabled";s:1:"0";s:8:"timezone";N;s:8:"language";N;s:18:"disable_login_form";s:1:"0";s:19:"twofactor_activated";b:0;s:16:"twofactor_secret";N;s:5:"token";s:0:"";s:20:"notifications_filter";s:1:"4";s:15:"nb_failed_login";s:1:"0";s:20:"lock_expiration_date";s:1:"0";s:9:"gitlab_id";N;s:4:"role".."
kanext-kanboard  | ."
kanext-kanboard  | PHP message: [debug] SQL: param[3]: '59uivo3tgqd8pm8kse2bglichk'"
kanext-kanboard  | PHP message: [debug] SQL: query_duration=3.0040740966797E-5"
kanext-kanboard  | PHP message: [debug] SQL: total_execution_time=0.0035891532897949"
kanext-kanboard  | PHP message: [debug] APP: nb_queries=7"
kanext-kanboard  | PHP message: [debug] APP: rendering_time=0.045599937438965"
kanext-kanboard  | PHP message: [debug] APP: memory_usage=788.41k"
kanext-kanboard  | PHP message: [debug] APP: uri=/?controller=UserAjaxController&action=status"
kanext-kanboard  | PHP message: [debug] ###############################################"
kanext-kanboard  | 2025/02/23 20:10:11 [error] 15#15: *5 FastCGI sent in stderr: "PHP message: [debug] Kanboard\Core\Controller\Runner::executeMiddleware; PHP message: [debug] Subscriber executed: Kanboard\Subscriber\BootstrapSubscriber::execute; PHP message: [debug] Kanboard\Core\Controller\BaseMiddleware::next => Kanboard\Middleware\AuthenticationMiddleware; PHP message: [debug] Kanboard\Core\Controller\BaseMiddleware::next => Kanboard\Middleware\PostAuthenticationMiddleware; PHP message: [debug] Kanboard\Core\Controller\BaseMiddleware::next => Kanboard\Middleware\ApplicationAuthorizationMiddleware; PHP message: [debug] Kanboard\Core\Controller\BaseMiddleware::next => Kanboard\Middleware\ProjectAuthorizationMiddleware; PHP message: [debug] Kanboard\Core\Controller\Runner::executeController => \Kanboard\Controller\UserAjaxController::status; PHP message: [debug] SQL: SELECT  "settings"."option", "settings"."value" FROM "settings"; PHP message: [debug] SQL: query_duration=0.00069594383239746; PHP message: [debug] SQL: total_execution_time=0.00069594383239746; PHP message: [debug] SQL: SELECT  "sessions"."data" FROM "sessions"   WHERE "id" = ? AND "expire_at" > ?    LIMIT 1; PHP message: [debug] SQL: param[1]: '59uivo3tgqd8pm8kse2bglichk'; PHP message: [debug] SQL: param[2]: '1740341411'; PHP message: [debug] SQL: query_duration=0.0016741752624512; PHP message: [debug] SQL: total_execution_time=0.0023701190948486; PHP message: [debug] SQL: SELECT  projects.id, projects.name FROM "projects" LEFT JOIN "project_has_users" ON "project_has_users"."project_id"="projects"."id"  WHERE project_has_users.user_id = ? AND projects.is_active IN (?); PHP message: [debug] SQL: param[1]: '1'; PHP message: [debug] SQL: param[2]: '1'; PHP message: [debug] SQL: query_duration=0.000946044921875; PHP message: [debug] SQL: total_execution_time=0.0033161640167236; PHP message: [debug] SQL: SELECT  projects.id, projects.name FROM "projects" LEFT JOIN "project_has_groups" ON "project_has_groups"."project_id"="projects"."id" LEFT JOIN "group_has_users" ON "
kanext-kanboard exited with code 0
```